### PR TITLE
Fix references without system, drop norg-table, fix neorg-telescope ref

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,13 @@
 
     norg.url = "github:nvim-neorg/tree-sitter-norg";
     norg-meta.url = "github:nvim-neorg/tree-sitter-norg-meta";
-    norg-table.url = "github:nvim-neorg/tree-sitter-norg-table";
 
     neorg = {
       url = "github:nvim-neorg/neorg";
       flake = false;
     };
     neorg-telescope = {
-      url = "github:nvim-neorg/neorg";
+      url = "github:nvim-neorg/neorg-telescope";
       flake = false;
     };
   };
@@ -19,9 +18,8 @@
     overlay = final: prev:
       with inputs; let
         grammars = {
-          tree-sitter-norg = norg.defaultPackage;
-          tree-sitter-norg-meta = norg-meta.defaultPackage;
-          tree-sitter-norg-table = norg-table.defaultPackage;
+          tree-sitter-norg = norg.defaultPackage.${final.system};
+          tree-sitter-norg-meta = norg-meta.defaultPackage.${final.system};
         };
       in
       {


### PR DESCRIPTION
I was finally able to repro the issue in https://github.com/nvim-neorg/tree-sitter-norg/issues/40, and the fix is simple 🙂 

I had to drop `norg-table` though — as you told me it's not gonna be used anymore I didn't add a PR to add the missing `systems` in there, and in my test consumer flake of this overlay I was getting the original issue from #1 again:

```sh
$ nix build .#nixosConfigurations.test.config.system.build.toplevel --show-trace
error: attribute 'currentSystem' missing

       at /nix/store/bn14fy2mc2p1q44681il8idfv5fr5x3z-source/pkgs/top-level/impure.nix:17:43:

           16|   # (build, in GNU Autotools parlance) platform.
           17|   localSystem ? { system = args.system or builtins.currentSystem; }
             |                                           ^
           18|
```
(norg and norg-meta flakes now expose e.g. `defaultPackage.x86_64-linux` but norg-table just has a `defaultPackage` without any system, and it always leads to the error above. I don't know why the naked `defaultPackage` fails for me and not for others, apparently, but as I noted in https://github.com/nvim-neorg/tree-sitter-norg/pull/39 a systemless flake output doesn't really make sense IMHO)

Hope this works for you?
