### PR TITLE
Use vimPlugin.extend, try to be more clever about treesitter grammars, add tests

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,18 @@
+name: check
+on:
+  push:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Run tests
+        run: nix flake check

--- a/README.md
+++ b/README.md
@@ -32,21 +32,26 @@ The following minimal NixOS [flake](https://nixos.wiki/wiki/Flakes) configures N
             programs.neovim = {
               enable = true;
               plugins = with pkgs.vimPlugins; [
-                # Installing all parsers including up-to-date Neorg parsers is a little bit more involved than usual:
-                # (nvim-treesitter.withPlugins (_: (builtins.filter pkgs.lib.isDerivation (builtins.attrValues pkgs.tree-sitter-grammars))))
-                # 
-                # The following will not install Neorg parsers:
-                # (nvim-treesitter.withPlugins (p: builtins.attrValues p))
+                neorg
+
+                # optional
+                neorg-telescope
+
+                # optional — only if you want additional grammars besides norg and
+                # norg_meta, otherwise auto-required.
                 #
-                # The following will try to install Neorg parsers as well but is more prone to compilation errors:
-                # (nvim-treesitter.withPlugins (_: pkgs.tree-sitter-grammars.allGrammars))
+                # N.b.: Don't use plain nvim-treesitter as it would result in no
+                # grammars getting installed, always the withPlugins function.
+                # The minimal form is nvim-treesitter.withPlugins (_: [ ]) — the norg
+                # grammars are added automatically.
+                #
+                # For all available grammars, nvim-treesitter.withAllGrammars or the
+                # equivalent nvim-treesitter.withPlugins (_: nvim-treesitter.allGrammars)
+                # can be used.
                 (nvim-treesitter.withPlugins (p: with p; [
                   # Keep calm and don't :TSInstall
                   tree-sitter-lua
-                  tree-sitter-norg
-                  tree-sitter-norg-meta
                 ]))
-                neorg
               ];
               extraConfig = ''
                 lua << EOF
@@ -76,6 +81,5 @@ The following minimal NixOS [flake](https://nixos.wiki/wiki/Flakes) configures N
 
 -   [`vimPlugins.neorg`](https://github.com/nvim-neorg/neorg)
 -   [`vimPlugins.neorg-telescope`](https://github.com/nvim-neorg/neorg-telescope)
--   [`tree-sitter-grammars.norg`](https://github.com/nvim-neorg/tree-sitter-norg)
--   [`tree-sitter-grammars.norg-meta`](https://github.com/nvim-neorg/tree-sitter-norg-meta)
--   [`tree-sitter-grammars.norg-table`](https://github.com/nvim-neorg/tree-sitter-norg-table)
+-   [`vimPlugins.nvim-treesitter.builtGrammars.tree-sitter-norg`](https://github.com/nvim-neorg/tree-sitter-norg)
+-   [`vimPlugins.nvim-treesitter.builtGrammars.tree-sitter-norg-meta`](https://github.com/nvim-neorg/tree-sitter-norg-meta)

--- a/flake.lock
+++ b/flake.lock
@@ -34,6 +34,21 @@
     },
     "flake-utils": {
       "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
@@ -47,7 +62,7 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -145,7 +160,7 @@
     "norg": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
@@ -165,7 +180,7 @@
     "norg-meta": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
@@ -184,6 +199,7 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "neorg": "neorg",
         "neorg-telescope": "neorg-telescope",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
+    flake-utils.url = "github:numtide/flake-utils";
+
     norg.url = "github:nvim-neorg/tree-sitter-norg";
     norg-meta.url = "github:nvim-neorg/tree-sitter-norg-meta";
 
@@ -14,34 +16,60 @@
       flake = false;
     };
   };
-  outputs = { self, nixpkgs, ... }@inputs: {
-    overlay = final: prev:
-      with inputs; let
-        grammars = {
-          tree-sitter-norg = norg.defaultPackage.${final.system};
-          tree-sitter-norg-meta = norg-meta.defaultPackage.${final.system};
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , norg
+    , norg-meta
+    , neorg
+    , neorg-telescope
+    , ...
+    }: {
+      overlays.default = final: prev:
+        let inherit (final.lib) attrValues elem filter filterAttrs isDerivation; in
+        {
+          vimPlugins = prev.vimPlugins.extend (f: p: {
+            nvim-treesitter =
+              let
+                norgGrammars = {
+                  tree-sitter-norg = norg.defaultPackage.${final.system};
+                  tree-sitter-norg-meta = norg-meta.defaultPackage.${final.system};
+                };
+                builtGrammars = (filterAttrs (_: isDerivation) p.nvim-treesitter.builtGrammars) // norgGrammars;
+                allGrammars = attrValues builtGrammars;
+                withPlugins = grammarFn:
+                  p.nvim-treesitter.withPlugins (_:
+                    let plugins = (grammarFn builtGrammars); in
+                    plugins ++ (filter (p: !(elem p plugins)) (attrValues norgGrammars))
+                  );
+                withAllGrammars = withPlugins (_: allGrammars);
+              in
+              p.nvim-treesitter.overrideAttrs (a:
+                {
+                  passthru = {
+                    inherit builtGrammars allGrammars withPlugins withAllGrammars;
+                  };
+                });
+            neorg = final.vimUtils.buildVimPluginFrom2Nix {
+              pname = "neorg";
+              version = neorg.rev;
+              src = neorg;
+              dependencies = [ f.plenary-nvim (f.nvim-treesitter.withPlugins (_: [ ])) ];
+            };
+            neorg-telescope = final.vimUtils.buildVimPluginFrom2Nix {
+              pname = "neorg-telescope";
+              version = neorg-telescope.rev;
+              src = neorg-telescope;
+              dependencies = [ f.telescope-nvim f.neorg ];
+            };
+          });
         };
-      in
-      {
-        vimPlugins = prev.vimPlugins // {
-          neorg = prev.vimUtils.buildVimPluginFrom2Nix {
-            pname = "neorg";
-            version = neorg.rev;
-            src = neorg;
-            buildInputs = [ prev.vimPlugins.plenary-nvim ];
-          };
-          neorg-telescope = prev.vimUtils.buildVimPluginFrom2Nix {
-            pname = "neorg-telescope";
-            version = neorg-telescope.rev;
-            src = neorg-telescope;
-            buildInputs = [ prev.vimPlugins.telescope-nvim final.vimPlugins.neorg ];
-          };
-        };
-        tree-sitter = prev.tree-sitter // {
-          allGrammars = (prev.lib.lists.remove prev.tree-sitter.builtGrammars.tree-sitter-norg prev.tree-sitter.allGrammars) ++ builtins.attrValues grammars;
-          builtGrammars = prev.tree-sitter.builtGrammars // grammars;
-        };
-        tree-sitter-grammars = prev.tree-sitter-grammars // grammars;
-      };
-  };
+    } // (flake-utils.lib.eachDefaultSystem (system: {
+      checks = import ./tests.nix
+        (import nixpkgs {
+          inherit system;
+          overlays = [ self.overlays.default ];
+        });
+    }));
 }

--- a/tests.nix
+++ b/tests.nix
@@ -1,0 +1,201 @@
+pkgs:
+let
+  inherit (pkgs.lib) concatStringsSep imap listToAttrs;
+  makeTest = { name, plugins, expectedPluginFiles, expectedParsers }:
+    let
+      config =
+        let base = (pkgs.neovimUtils.makeNeovimConfig { inherit plugins; });
+        in base // {
+          wrapRc = false;
+          wrapperArgs = base.wrapperArgs ++ [
+            "--add-flags"
+            "'-u' '${
+                pkgs.writeText "init.lua" ''
+                  function test()
+                    local success = true
+
+                    require("nvim-treesitter.configs").setup({})
+                    local parsers = require("nvim-treesitter.parsers")
+                    for _, p in ipairs({${
+                      concatStringsSep "," (map (p: ''"${p}"'') expectedParsers)
+                    }}) do
+                      if not parsers.has_parser(p) then
+                        print("${name}: missing parser: " .. p)
+                        success = false
+                      end
+                    end
+
+                    function has_script(scripts, script)
+                      local filtered = vim.tbl_filter(
+                        function(s)
+                          return string.find(s, script, 1, true)
+                        end, scripts
+                      )
+                      return #filtered > 0
+                    end
+                    local scripts = vim.split(
+                      vim.api.nvim_exec("scriptnames", true), "\n", {trimempty = true}
+                    )
+                    for _, s in ipairs({${
+                      concatStringsSep "," (map (p: ''"${p}"'') expectedPluginFiles)
+                    }}) do
+                      if not has_script(scripts, s) then
+                        print("${name}: missing plugin script:", s)
+                        success = false
+                      end
+                    end
+
+                    print("${name}-result:", success)
+                  end
+
+                  vim.cmd("autocmd BufEnter * lua test()")
+                ''
+              }'"
+          ];
+        };
+      nvim = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped config;
+    in
+    pkgs.runCommand name { } ''
+      tmp=$(mktemp -d)
+      cleanup() {
+        if [[ -d $tmp ]]; then
+          rm -rf "$tmp"
+        fi
+      }
+      trap cleanup EXIT
+      HOME=$tmp
+      output=$("${nvim}"/bin/nvim -es --cmd "redi! > /dev/stdout" -c "redi end|q!")
+      printf "%s\n" "''${output//${name}-result: */}"
+      touch $out
+      [[ "$(tail -n 1 <<<"$output")" == "${name}-result: true" ]]
+    '';
+  tests =
+    let
+      pluginMarkers = {
+        neorg = "ftdetect/norg.vim";
+        plenary = "plugin/plenary.vim";
+        nvim-treesitter = "plugin/nvim-treesitter.lua";
+        telescope = "plugin/telescope.lua";
+      };
+    in
+    [
+      {
+        # 1. Just neorg — should automatically pull in plugin and parser dependencies
+        plugins = with pkgs.vimPlugins; [ neorg ];
+        expectedPluginFiles = with pluginMarkers; [ neorg plenary nvim-treesitter ];
+        expectedParsers = [
+          "norg"
+          "norg_meta"
+        ];
+      }
+      # 2. Additional parser — should add to our parsers.
+      {
+        plugins = with pkgs.vimPlugins; [
+          neorg
+          (nvim-treesitter.withPlugins (p: [ p.tree-sitter-bash ]))
+        ];
+        expectedPluginFiles = with pluginMarkers; [ neorg plenary nvim-treesitter ];
+        expectedParsers = [ "bash" "norg" "norg_meta" ];
+      }
+      # 3. Requesting just norg parser — should add norg_meta parser.
+      {
+        plugins = with pkgs.vimPlugins; [
+          neorg
+          (nvim-treesitter.withPlugins (p: [ p.tree-sitter-norg ]))
+        ];
+        expectedPluginFiles = with pluginMarkers; [ neorg plenary nvim-treesitter ];
+        expectedParsers = [ "norg" "norg_meta" ];
+      }
+      # 4. Requesting norg and norg-meta parsers — shouldn't lead to duplicates (which
+      #    would fail the derivation of the parser dir)
+      {
+        plugins = with pkgs.vimPlugins; [
+          neorg
+          (nvim-treesitter.withPlugins
+            (p: [ p.tree-sitter-norg p.tree-sitter-norg-meta ]))
+        ];
+        expectedPluginFiles = with pluginMarkers; [ neorg plenary nvim-treesitter ];
+        expectedParsers = [ "norg" "norg_meta" ];
+      }
+      # 5. Requesting norg and unrelated parser — should add norg-meta.
+      {
+        plugins = with pkgs.vimPlugins; [
+          neorg
+          (nvim-treesitter.withPlugins (p: [ p.tree-sitter-bash p.tree-sitter-norg ]))
+        ];
+        expectedPluginFiles = with pluginMarkers; [ neorg plenary nvim-treesitter ];
+        expectedParsers = [ "norg" "norg_meta" "bash" ];
+      }
+      # 6. withAllGrammars — should include our parsers…
+      {
+        plugins = with pkgs.vimPlugins; [ neorg nvim-treesitter.withAllGrammars ];
+        expectedPluginFiles = with pluginMarkers; [ neorg plenary nvim-treesitter ];
+        expectedParsers = [
+          "norg"
+          "norg_meta"
+          # exemplary for "all":
+          "bash"
+          "perl"
+        ];
+      }
+      # 7. …using allGrammars — as in 6.
+      {
+        plugins = with pkgs.vimPlugins; [
+          neorg
+          (nvim-treesitter.withPlugins (_: nvim-treesitter.allGrammars))
+        ];
+        expectedPluginFiles = with pluginMarkers; [ neorg plenary nvim-treesitter ];
+        expectedParsers = [
+          "norg"
+          "norg_meta"
+          # exemplary for "all":
+          "bash"
+          "perl"
+        ];
+      }
+      # 8. Requesting just neorg-telescope — should pull in all required vim plugins and
+      #    our parsers…
+      {
+        plugins = with pkgs.vimPlugins; [ neorg-telescope ];
+        expectedPluginFiles = with pluginMarkers; [
+          telescope
+          neorg
+          plenary
+          nvim-treesitter
+        ];
+        expectedParsers = [ "norg" "norg_meta" ];
+      }
+      # 9. …with explicit neorg request — as in 8. …
+      {
+        plugins = with pkgs.vimPlugins; [ neorg neorg-telescope ];
+        expectedPluginFiles = with pluginMarkers; [
+          telescope
+          neorg
+          plenary
+          nvim-treesitter
+        ];
+        expectedParsers = [ "norg" "norg_meta" ];
+      }
+      # 10. …with explicit parser request — should result in requested parser + ours (+
+      #     vim plugin deps as before)…
+      {
+        plugins = with pkgs.vimPlugins; [
+          neorg-telescope
+          (nvim-treesitter.withPlugins (p: [ p.tree-sitter-bash ]))
+        ];
+        expectedPluginFiles = with pluginMarkers; [
+          telescope
+          neorg
+          plenary
+          nvim-treesitter
+        ];
+        expectedParsers = [ "norg" "norg_meta" "bash" ];
+      }
+    ];
+in
+listToAttrs (imap
+  (i: test: rec {
+    name = "test${toString i}";
+    value = makeTest (test // { inherit name; });
+  })
+  tests)


### PR DESCRIPTION
My stab at #3.
I've tried to make everything work automagically, and added tests that show intended usage. I also updated the README accordingly. What do you think? Note that I moved the grammar patches to nvim-treesitter, it works a bit differently than tree-sitter (since recently I think).

> 
> vimPlugin.extend should prevent inter-plugin dependency breakage.
> `vimPlugins.nvim-treesitter.{withPlugins,withAllGrammars}` now auto-adds the required norg grammars. I didn't find a way to make plain `vimPlugins.nvim-treesitter` work without triggering inifinite recursion.
> 
> See the tests for for detailed behaviour. I also added a GitHub workflow that runs them.