### PR TITLE
Reinstate .overlay but warn about deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following minimal NixOS [flake](https://nixos.wiki/wiki/Flakes) configures N
       modules = [
         home-manager.nixosModules.home-manager
         {
-          nixpkgs.overlays = [ neorg-overlay.overlay ];
+          nixpkgs.overlays = [ neorg-overlay.overlays.default ];
           home-manager.users.bandithedoge = {
             programs.neovim = {
               enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,8 @@
             };
           });
         };
+      # https://github.com/NixOS/nix/issues/5532
+      overlay = nixpkgs.lib.warn "`neorg-overlay.overlay` is deprecated; use `neorg-overlay.overlays.default` instead" self.overlays.default;
     } // (flake-utils.lib.eachDefaultSystem (system: {
       checks = import ./tests.nix
         (import nixpkgs {


### PR DESCRIPTION
I over-eagerly removed `.overlay` in my last PR, it's deprecated and should be `.overlays.default` (see https://github.com/NixOS/nix/issues/5532), but this would break current users.
I reinstated `.overlay` and display a warning, and updated README to reflect that.

Cheers