### PR TITLE
fix deprecated buildVimPluginFrom2Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696693680,
-        "narHash": "sha256-PH0HQTkqyj7DmdPKPwrrXwVURLBqzZs4nqnDw9q8mhg=",
+        "lastModified": 1696725822,
+        "narHash": "sha256-B7uAOS7TkLlOg1aX01rQlYbydcyB6ZnLJSfaYbKVww8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "945559664c1dc5836173ee12896ba421d9b37181",
+        "rev": "5aabb5780a11c500981993d49ee93cfa6df9307b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -51,13 +51,13 @@
                     inherit builtGrammars allGrammars withPlugins withAllGrammars;
                   };
                 });
-            neorg = final.vimUtils.buildVimPluginFrom2Nix {
+            neorg = final.vimUtils.buildVimPlugin {
               pname = "neorg";
               version = neorg.rev;
               src = neorg;
               dependencies = [ f.plenary-nvim (f.nvim-treesitter.withPlugins (_: [ ])) ];
             };
-            neorg-telescope = final.vimUtils.buildVimPluginFrom2Nix {
+            neorg-telescope = final.vimUtils.buildVimPlugin {
               pname = "neorg-telescope";
               version = neorg-telescope.rev;
               src = neorg-telescope;


### PR DESCRIPTION
replace the deprecated `buildVimPluginFrom2Nix` with `buildVimPlugin`, see https://github.com/NixOS/nixpkgs/commit/0ab2c9642991c787c38cc131e7c5c935bff9cd88