### PR TITLE
Adds passthru.grammarPlugins to match nixpkgs nvim-treesitter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,8 +48,12 @@
             withAllGrammars = withPlugins (_: allGrammars);
           in
             p.nvim-treesitter.overrideAttrs (a: {
-              passthru = {
+              passthru = a.passthru // {
                 inherit builtGrammars allGrammars withPlugins withAllGrammars;
+		grammarPlugins = a.passthru.grammarPlugins // {
+			norg = norgGrammars.tree-sitter-norg;
+			norg-meta = norgGrammars.tree-sitter-norg-meta;
+		};
               };
             });
           lua-utils-nvim = final.vimUtils.buildVimPlugin {


### PR DESCRIPTION
Matches the api in nixpkgs to make sure all grammars defined there are also passed through. 