### PR TITLE
additions to grammarPlugins should be passed through grammarToPlugin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,8 +51,8 @@
               passthru = a.passthru // {
                 inherit builtGrammars allGrammars withPlugins withAllGrammars;
 		grammarPlugins = a.passthru.grammarPlugins // {
-			norg = norgGrammars.tree-sitter-norg;
-			norg-meta = norgGrammars.tree-sitter-norg-meta;
+			norg = p.nvim-treesitter.grammarToPlugin norgGrammars.tree-sitter-norg;
+			norg-meta = p.nvim-treesitter.grammarToPlugin norgGrammars.tree-sitter-norg-meta;
 		};
               };
             });


### PR DESCRIPTION
closes https://github.com/nvim-neorg/nixpkgs-neorg-overlay/issues/10 (a build failure, doesnt work at all until the PR goes through)